### PR TITLE
🔀 Add middleware to redirect /AGM to /agm

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === "/AGM") {
+    return NextResponse.redirect(new URL("/agm", request.url), 308);
+  }
+}
+
+export const config = {
+  matcher: "/AGM",
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
 };
 
 export default nextConfig;


### PR DESCRIPTION
Adds a permanent (308) redirect from the uppercase `/AGM` path to `/agm` for case-insensitive URL handling. Also removes the unused config comment from `next.config.ts`.